### PR TITLE
Get dependencies from `spago`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+### Project-specific ###
+.spago
+
 # Created by https://www.gitignore.io/api/vim,node,macos,bower,linux,emacs,windows,purescript,sublimetext,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=vim,node,macos,bower,linux,emacs,windows,purescript,sublimetext,visualstudiocode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,12 +103,6 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
-    "bower": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.12.tgz",
-      "integrity": "sha512-u1xy9SrwwoPlgjuHNjhV+YUPVdqyBj2ALBxuzeIUKXaPI2i2xypGgxqXkuHcITGdi5yBj5JuXgyMvgiWiS1S3Q==",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1108,6 +1102,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "spago": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/spago/-/spago-0.19.1.tgz",
+      "integrity": "sha512-OD/yopJZ9Ub+XsFtayDeLAWLT4kLdMxosJEyyp8W5OkyJVVSbCrvYacsO7iq3lSuHJmmNny/TEZdyb7uSyupng==",
+      "dev": true,
+      "requires": {
+        "request": "^2.88.0",
+        "tar": "^4.4.8"
+      }
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "author": "Hardy Jones <jones3.hardy@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.8.12",
     "pscid": "^2.9.3",
     "purescript": "^0.13.8",
-    "purescript-psa": "^0.8.2"
+    "purescript-psa": "^0.8.2",
+    "spago": "^0.19.1"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,20 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+
+in  upstream
+  with spec =
+    { dependencies =
+      [ "aff"
+      , "ansi"
+      , "console"
+      , "exceptions"
+      , "foldable-traversable"
+      , "generics-rep"
+      , "pipes"
+      , "prelude"
+      , "strings"
+      , "transformers"
+      ]
+    , repo = "https://github.com/purescript-spec/purescript-spec.git"
+    , version = "v3.1.1"
+    }

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,21 @@
+{ name = "resource"
+, dependencies =
+  [ "aff"
+  , "console"
+  , "control"
+  , "effect"
+  , "newtype"
+  , "prelude"
+  , "psci-support"
+  , "refs"
+  , "spec"
+  ]
+, packages = ./packages.dhall
+, sources =
+  [ "src/Codensity.purs"
+  , "src/Ran.purs"
+  , "src/Resource.purs"
+  , "src/Resource/Unsafe.purs"
+  , "test/Test/Main.purs"
+  ]
+}


### PR DESCRIPTION
We can't really update any dependencies with `bower` these days.

Given that ecosystem is dealing with a bunch of breaking changes due to
0.14.0, and the response to the breaking changes is to also change how
dependencies are resolved, we jump on the bandwagon and abandon `bower`.

We still don't change the build so we're reliant on `spago` for actually
building, since it's one extra layer we don't really care to deal with.