### PR TITLE
Bump `purescript` to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,9 +923,9 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.8.tgz",
-      "integrity": "sha512-1ZyVEVFLgcEcjPXxJYeVEyYn66DF2DnOLTWzo/K/MrQUF2chdLSyZ8sJpcarWyrz2HxXaubYceYbo5KexKzynA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.0.tgz",
+      "integrity": "sha512-iTA1k8mwxHqrJp/K296g6omVfve5RCjnB5D6Up93PVtZdP66mCIqlOYC4hrLBHg2hgkk27xePDt5NUXKvH4ApQ==",
       "dev": true,
       "requires": {
         "purescript-installer": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "pscid": "^2.9.3",
-    "purescript": "^0.13.8",
+    "purescript": "^0.14.0",
     "purescript-psa": "^0.8.2",
     "spago": "^0.19.1"
   }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,22 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
-
+      https://raw.githubusercontent.com/purescript/package-sets/9f4d289897cdb16e193097b1cb009714366cebe2/src/packages.dhall sha256:710b53c085a18aa1263474659daa0ae15b7a4f453158c4f60ab448a6b3ed494e
 in  upstream
-  with spec.version = "v4.0.1"
+  with spec =
+    { dependencies =
+      [ "aff"
+      , "ansi"
+      , "avar"
+      , "console"
+      , "exceptions"
+      , "foldable-traversable"
+      , "fork"
+
+      , "now"
+      , "pipes"
+      , "prelude"
+      , "strings"
+      , "transformers"
+      ]
+    , repo = "https://github.com/fsoikin/purescript-spec.git"
+    , version = "28c9c6627777cbdd73a67894657b8b711ef003ca"
+    }

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,19 +2,4 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
 
 in  upstream
-  with spec =
-    { dependencies =
-      [ "aff"
-      , "ansi"
-      , "console"
-      , "exceptions"
-      , "foldable-traversable"
-      , "generics-rep"
-      , "pipes"
-      , "prelude"
-      , "strings"
-      , "transformers"
-      ]
-    , repo = "https://github.com/purescript-spec/purescript-spec.git"
-    , version = "v3.1.1"
-    }
+  with spec.version = "v3.1.1"

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,4 +2,4 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
 
 in  upstream
-  with spec.version = "v3.1.1"
+  with spec.version = "v4.0.1"

--- a/src/Codensity.purs
+++ b/src/Codensity.purs
@@ -14,6 +14,10 @@ import Effect.Aff.Class as Effect.Aff.Class
 import Effect.Class as Effect.Class
 import Ran as Ran
 
+type Codensity ::
+  (Type -> Type) ->
+  Type ->
+  Type
 type Codensity f a
   = Ran.Ran f f a
 

--- a/src/Ran.purs
+++ b/src/Ran.purs
@@ -12,6 +12,11 @@ import Effect.Aff as Effect.Aff
 import Effect.Aff.Class as Effect.Aff.Class
 import Effect.Class as Effect.Class
 
+type Ran ::
+  (Type -> Type) ->
+  (Type -> Type) ->
+  Type ->
+  Type
 type Ran f g a
   = forall b. (a -> f b) -> g b
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -9,12 +9,14 @@ import Effect.Ref as Effect.Ref
 import Resource as Resource
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
-import Test.Spec.Assertions.Aff as Test.Spec.Assertions.Aff
 import Test.Spec.Reporter as Test.Spec.Runner.Repoter
 import Test.Spec.Runner as Test.Spec.Runner
 
 main :: Effect.Effect Unit
-main = Test.Spec.Runner.run [Test.Spec.Runner.Repoter.specReporter] do
+main = Effect.Aff.launchAff_ spec
+
+spec :: Effect.Aff.Aff Unit
+spec = Test.Spec.Runner.runSpec [Test.Spec.Runner.Repoter.specReporter] do
   Test.Spec.describe "Resource" do
     Test.Spec.describe "run" do
       Test.Spec.it "acquires and releases resources in the correct order" do
@@ -43,7 +45,7 @@ main = Test.Spec.Runner.run [Test.Spec.Runner.Repoter.specReporter] do
       Test.Spec.it "releases resources even with an exception" do
         results <- Effect.Class.liftEffect (Effect.Ref.new mempty)
 
-        Test.Spec.Assertions.Aff.expectError $ Resource.run do
+        Test.Spec.Assertions.expectError $ Resource.run do
           _ <- new results "foo"
           _ <- new results "bar"
           Resource.new (Effect.Aff.throwError $ Effect.Aff.error "break") pure


### PR DESCRIPTION
We bring up the `purescript` dependency up to date.