### PR TITLE
Use a release for the package set

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,6 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/9f4d289897cdb16e193097b1cb009714366cebe2/src/packages.dhall sha256:710b53c085a18aa1263474659daa0ae15b7a4f453158c4f60ab448a6b3ed494e
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0/packages.dhall sha256:710b53c085a18aa1263474659daa0ae15b7a4f453158c4f60ab448a6b3ed494e
+
 in  upstream
   with spec =
     { dependencies =
@@ -10,7 +11,6 @@ in  upstream
       , "exceptions"
       , "foldable-traversable"
       , "fork"
-
       , "now"
       , "pipes"
       , "prelude"


### PR DESCRIPTION
There's a release now, so we can use that.